### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./app/package-lock.json
+      - run: npm ci
+        working-directory: ./app
+      - run: npm run build -- --base=/scriptrans/
+        working-directory: ./app
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./app/dist
+      - uses: actions/deploy-pages@v2
+

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ npm run build
 ```
 
 The service worker will cache the application shell so that when you go offline the basic UI remains available.
+
+Auto deploy: push → master
+
+Manual deploy: Actions → Run workflow

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
+  base: '/scriptrans/',
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- automate page deployment with GitHub Actions
- configure Vite base path for GitHub Pages
- document auto and manual deploy in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c10ac0a148320aba0cbadedb2fb87