### PR TITLE
Update GitHub Pages actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,8 +28,8 @@ jobs:
         working-directory: ./app
       - run: npm run build -- --base=/scriptrans/
         working-directory: ./app
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3 # GitHub disables v2 on 30 Jan 2025
         with:
           path: ./app/dist
-      - uses: actions/deploy-pages@v2
+      - uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Summary
- bump `upload-pages-artifact` to v3
- bump `deploy-pages` to v4
- mention that v2 will be disabled 30 Jan 2025

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c18bffd588320ba8c04815d3b42c6