### PR TITLE
Fix PWA start_url and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ The service worker will cache the application shell so that when you go offline 
 Auto deploy: push → master
 
 Manual deploy: Actions → Run workflow
+
+## PWA: Add to Home Screen
+
+To test the app as a Progressive Web App on iOS:
+
+1. Open `https://ivanx32.github.io/scriptrans` in Safari.
+2. Use **Share → Add to Home Screen**.
+3. Launch the installed app from the Home Screen.
+
+The app should start without a 404 error and all routes will work offline.

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && cp dist/index.html dist/404.html && touch dist/.nojekyll",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "Scriptrans",
   "short_name": "Scriptrans",
-  "start_url": "/",
+  "start_url": "/scriptrans/",
+  "scope": "/scriptrans/",
   "display": "standalone",
   "theme_color": "#ffffff",
   "icons": [

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
       manifest: {
         name: 'Scriptrans',
         short_name: 'Scriptrans',
-        start_url: '/',
+        start_url: '/scriptrans/',
+        scope: '/scriptrans/',
         display: 'standalone',
         theme_color: '#ffffff',
         icons: [


### PR DESCRIPTION
## Summary
- ensure manifest start_url/scope use `/scriptrans/`
- copy index.html to 404.html and generate `.nojekyll`
- update Vite PWA config to match the new URL
- document installing the PWA on iOS

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c1cbc9cb4832080cbc432980aea35