### PR TITLE
Fix build script for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: ./app/package-lock.json
       - run: npm ci
         working-directory: ./app
-      - run: npm run build -- --base=/scriptrans/
+      - run: npm run build
         working-directory: ./app
       - uses: actions/upload-pages-artifact@v3 # GitHub disables v2 on 30 Jan 2025
         with:

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build && cp dist/index.html dist/404.html && touch dist/.nojekyll",
+    "build": "tsc -b && vite build --base=/scriptrans/ && cp dist/index.html dist/404.html && touch dist/.nojekyll",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- configure `build` npm script to pass base flag to `vite` and not to `touch`
- simplify GitHub Pages workflow

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c21908fb88320992226f6d41943d6