### PR TITLE
Implement service worker caching

### DIFF
--- a/app/public/offline.html
+++ b/app/public/offline.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Offline</title>
+    <style>
+      body { display:flex; flex-direction:column; align-items:center; justify-content:center; height:100vh; font-family:sans-serif; }
+      img { width:96px; height:96px; margin-bottom:1rem; }
+    </style>
+  </head>
+  <body>
+    <img src="/icons/placeholder.svg" alt="Logo" />
+    <p>No connection</p>
+  </body>
+</html>

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,11 +1,16 @@
-/// <reference types="vite-plugin-pwa/client" />
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
-import { registerSW } from 'virtual:pwa-register';
+import { Workbox } from 'workbox-window';
 
-registerSW({ immediate: true });
+if ('serviceWorker' in navigator) {
+  const wb = new Workbox(`${import.meta.env.BASE_URL}sw.js`);
+  wb.addEventListener('waiting', () => {
+    wb.messageSW({ type: 'SKIP_WAITING' });
+  });
+  wb.register();
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/app/src/sw.ts
+++ b/app/src/sw.ts
@@ -1,0 +1,57 @@
+/// <reference lib="webworker" />
+
+import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { CacheFirst, NetworkFirst } from 'workbox-strategies';
+import { setCacheNameDetails } from 'workbox-core';
+
+// self.__WB_MANIFEST is replaced at build time
+
+declare const self: ServiceWorkerGlobalScope;
+declare const __SW_VERSION__: string;
+
+const CACHE_NAME = `shell-v${__SW_VERSION__}`;
+setCacheNameDetails({ precache: CACHE_NAME, prefix: '', suffix: '' });
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((k) => k.startsWith('shell-v') && k !== CACHE_NAME)
+          .map((k) => caches.delete(k))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') self.skipWaiting();
+});
+
+precacheAndRoute(self.__WB_MANIFEST);
+precacheAndRoute([{ url: '/offline.html', revision: '' }]);
+
+registerRoute(
+  /\.(?:js|css|html|ico|png|svg)$/, 
+  new CacheFirst({ cacheName: CACHE_NAME })
+);
+
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  async (options) => {
+    const networkFirst = new NetworkFirst({ cacheName: CACHE_NAME });
+    let response: Response | undefined;
+    try {
+      response = await networkFirst.handle(options);
+    } catch {}
+    return (response ?? (await caches.match('/offline.html'))) as Response;
+  }
+);
+

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -4,11 +4,20 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
   base: '/scriptrans/',
+  define: {
+    __SW_VERSION__: JSON.stringify(Date.now().toString())
+  },
   plugins: [
     react(),
     VitePWA({
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
       registerType: 'autoUpdate',
-      includeAssets: ['icons/placeholder.svg'],
+      includeAssets: ['icons/placeholder.svg', 'offline.html'],
+      injectManifest: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,json}']
+      },
       manifestFilename: 'manifest.json',
       manifest: {
         name: 'Scriptrans',


### PR DESCRIPTION
## Summary
- add minimal offline page
- add Workbox service worker for cache-first shell assets and offline fallback for navigations
- register the service worker with Workbox client and trigger skip waiting
- configure vite-plugin-pwa to use custom service worker

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c251b357883209276c95dc0e962eb