### PR TITLE
Fix router basename for folder deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ npm run dev
 npm run build
 ```
 
+To serve the app from a subfolder, pass the desired base path to Vite:
+
+```bash
+vite build --base=/your-folder/
+```
+
+The router reads `import.meta.env.BASE_URL`, so navigation works automatically.
+
 The service worker will cache the application shell so that when you go offline the basic UI remains available.
 
 Auto deploy: push → master

--- a/app/cypress.config.ts
+++ b/app/cypress.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from 'cypress';
 
+const base = process.env.VITE_BASE_URL ?? '/scriptrans/';
+
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:4173/scriptrans/',
+    baseUrl: `http://localhost:4173${base}`,
     setupNodeEvents() {},
     supportFile: false
+  },
+  env: {
+    BASE_URL: base
   }
 });

--- a/app/cypress/e2e/flow.cy.ts
+++ b/app/cypress/e2e/flow.cy.ts
@@ -1,14 +1,14 @@
 describe('basic flow', () => {
   it('upload to editor', () => {
     cy.visit('/');
-    cy.url().should('include', '/upload');
+    cy.url().should('include', `${Cypress.env('BASE_URL')}upload`);
     cy.get('input[type=file]').selectFile('cypress/fixtures/sample.wav', { force: true });
     cy.contains('button', 'Start').click();
     cy.contains('Transcribing');
     cy.contains('Transcribing', { timeout: 5000 });
-    cy.url({ timeout: 5000 }).should('include', '/editor');
+    cy.url({ timeout: 5000 }).should('include', `${Cypress.env('BASE_URL')}editor`);
     cy.get('textarea').should('contain.value', 'Lorem ipsum');
     cy.contains('Back to Upload').click();
-    cy.url().should('include', '/upload');
+    cy.url().should('include', `${Cypress.env('BASE_URL')}upload`);
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -44,7 +44,7 @@ export default function App() {
   }, []);
 
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <FileContext.Provider value={{ file, setFile }}>
         <Header />
         {!online && (


### PR DESCRIPTION
## Summary
- use `basename` in router for subpath deploys
- pass Vite base to Cypress tests
- update flow test for new BASE_URL env
- document `--base` flag in README

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686c384781a883209ff102001cb1d33a