### PR TITLE
Fix Playwright setup and ignore wasm binary

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,0 +1,26 @@
+name: build-wasm
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./app/package-lock.json
+      - name: Bootstrap emsdk
+        run: ./scripts/bootstrap.sh
+      - name: Build wasm
+        run: ./scripts/build-wasm.sh
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm
+          path: public/wasm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,8 @@ jobs:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: ./app/package-lock.json
+      - run: ../scripts/check_size.sh
       - run: npm ci
       - run: npm run test:e2e
+      - run: npx playwright install --with-deps
+      - run: npm run test:playwright

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore built WASM artifacts
+app/public/wasm/whisper.wasm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: local
+    hooks:
+      - id: size-check
+        name: Check binary sizes
+        entry: ./scripts/check_size.sh
+        language: script

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
+        "@playwright/test": "^1.44.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.2",
@@ -2570,6 +2571,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -7549,6 +7566,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test:e2e": "npm run build && start-server-and-test 'vite preview --port=4173' http://localhost:4173 'cypress run'"
+    ,
+    "test:playwright": "npm run build && NODE_PATH=./node_modules playwright test"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -33,6 +35,7 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "cypress": "^13.7.3",
-    "start-server-and-test": "^2.0.3"
+    "start-server-and-test": "^2.0.3",
+    "@playwright/test": "^1.44.1"
   }
 }

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run preview',
+    port: 4173
+  },
+  testDir: '../tests',
+});

--- a/app/public/test-whisper.html
+++ b/app/public/test-whisper.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<script type="module">
+import Module from './wasm/whisper.js';
+import { loadModel } from '/src/wasm/loader.ts';
+Module().then(async (mod) => {
+  console.log('Whisper ready');
+  await loadModel(mod, 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-ru.bin');
+});
+</script>
+</body>
+</html>

--- a/app/public/wasm/whisper.js
+++ b/app/public/wasm/whisper.js
@@ -1,0 +1,1 @@
+// wasm placeholder

--- a/app/src/wasm/loader.ts
+++ b/app/src/wasm/loader.ts
@@ -1,0 +1,7 @@
+export async function loadModel(Module: any, url: string) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch model: ${res.status}`);
+  const buf = await res.arrayBuffer();
+  Module.FS_writeFile('/tiny.bin', new Uint8Array(buf));
+  console.log('Model ok');
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,9 @@
+set -e
+EMSDK_VERSION=3.1.60
+if [ ! -d emsdk ]; then
+  git clone https://github.com/emscripten-core/emsdk.git
+fi
+cd emsdk
+./emsdk install $EMSDK_VERSION
+./emsdk activate $EMSDK_VERSION
+source ./emsdk_env.sh

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,0 +1,16 @@
+set -e
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+WHISPER_REPO="https://github.com/ggerganov/whisper.cpp"
+if [ ! -d whisper.cpp ]; then
+  git clone --depth=1 $WHISPER_REPO
+fi
+mkdir -p whisper.cpp/build
+cd whisper.cpp/build
+cmake .. \
+  -DWHISPER_WASM_SIMD=ON \
+  -DWHISPER_WASM_THREADS=OFF \
+  -DWHISPER_WASM_SINGLE_FILE=ON
+make -j$(nproc)
+mkdir -p "$PROJECT_ROOT/public/wasm"
+cp whisper.wasm whisper.js "$PROJECT_ROOT/public/wasm/"

--- a/scripts/check_size.sh
+++ b/scripts/check_size.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+MAX=8000000
+for f in $(git ls-files -z | xargs -0 stat -c '%n:%s'); do
+  size=${f##*:}
+  file=${f%:*}
+  if [[ $size -gt $MAX ]]; then
+    echo "Error: $file exceeds ${MAX} bytes" >&2
+    exit 1
+  fi
+done

--- a/scripts/fetch_model.sh
+++ b/scripts/fetch_model.sh
@@ -1,0 +1,4 @@
+set -e
+MODEL_URL="https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-ru.bin"
+OUTPUT=ggml-tiny-ru.bin
+curl -L -o "$OUTPUT" "$MODEL_URL"

--- a/tests/whisper.spec.ts
+++ b/tests/whisper.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ browserName: 'webkit' });
+
+test('whisper wasm loads', async ({ page }) => {
+  const messages: string[] = [];
+  page.on('console', msg => messages.push(msg.text()));
+  await page.goto('http://localhost:4173/test-whisper.html');
+  await expect.poll(() => messages.includes('Whisper ready')).toBe(true);
+  await expect.poll(() => messages.includes('Model ok')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- ignore generated `whisper.wasm`
- tweak Playwright config paths
- run Playwright with NODE_PATH so tests resolve modules

## Testing
- `./scripts/check_size.sh`
- `npm run test:playwright` *(fails: Whisper ready log not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3d93f5d4832095c5cce5edd4fcb9