### PR TITLE
Fix wasm build workflow

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -15,10 +15,16 @@ jobs:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: ./app/package-lock.json
-      - name: Bootstrap emsdk
-        run: ./scripts/bootstrap.sh
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 3.1.60
       - name: Build wasm
         run: ./scripts/build-wasm.sh
+      - name: Post-build checks
+        run: |
+          wasm-feature detect public/wasm/whisper.wasm | grep -q "simd:true"
+          test -f public/wasm/whisper.js
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,16 +1,37 @@
-set -e
+set -euo pipefail
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 WHISPER_REPO="https://github.com/ggerganov/whisper.cpp"
-if [ ! -d whisper.cpp ]; then
-  git clone --depth=1 $WHISPER_REPO
+
+# Ensure Emscripten is active
+if [ -f "$HOME/emsdk/emsdk_env.sh" ]; then
+  # shellcheck disable=SC1090
+  source "$HOME/emsdk/emsdk_env.sh"
 fi
+
+if [ ! -d whisper.cpp ]; then
+  git clone --depth=1 "$WHISPER_REPO"
+fi
+
 mkdir -p whisper.cpp/build
 cd whisper.cpp/build
-cmake .. \
+
+emcmake cmake .. \
+  -DWHISPER_WASM=ON \
   -DWHISPER_WASM_SIMD=ON \
   -DWHISPER_WASM_THREADS=OFF \
-  -DWHISPER_WASM_SINGLE_FILE=ON
-make -j$(nproc)
-mkdir -p "$PROJECT_ROOT/public/wasm"
-cp whisper.wasm whisper.js "$PROJECT_ROOT/public/wasm/"
+  -DWHISPER_WASM_SINGLE_FILE=ON \
+  -DWHISPER_BUILD_TESTS=OFF \
+  -DWHISPER_BUILD_EXAMPLES=OFF
+
+emmake make -j"$(nproc)"
+
+DEST="${GITHUB_WORKSPACE:-$PROJECT_ROOT}/public/wasm"
+mkdir -p "$DEST"
+cp whisper.wasm whisper.js "$DEST/"
+
+# Copy license
+LICENSE_DEST="$PROJECT_ROOT/third_party"
+mkdir -p "$LICENSE_DEST"
+cp ../LICENSE "$LICENSE_DEST/LICENSE-whisper-cpp"


### PR DESCRIPTION
## Summary
- fix build-wasm.sh to use emcmake/emmake and copy license
- update GitHub Actions to setup emsdk and run checks

## Testing
- `pre-commit run --files scripts/build-wasm.sh .github/workflows/build-wasm.yml`

------
https://chatgpt.com/codex/tasks/task_e_686c470d44f083209d7e9d13d12803eb