### PR TITLE
Fix wasm-feature step

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -19,6 +19,10 @@ jobs:
         uses: mymindstorm/setup-emsdk@v14
         with:
           version: 3.1.60
+      - name: Install wasm-feature
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y binaryen
       - name: Build wasm
         run: ./scripts/build-wasm.sh
       - name: Post-build checks


### PR DESCRIPTION
## Summary
- install Binaryen package to get wasm-feature in CI

## Testing
- `pre-commit run --files .github/workflows/build-wasm.yml`
- `npm run test:playwright` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c5184cf1c8320b04fec351b249e92