### PR TITLE
Fix wasm feature check using Binaryen

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -19,13 +19,15 @@ jobs:
         uses: mymindstorm/setup-emsdk@v14
         with:
           version: 3.1.60
+      - name: Install Binaryen
+        run: sudo apt-get update -qq && sudo apt-get install -y binaryen
       - name: Build wasm
         run: ./scripts/build-wasm.sh
       - name: Check SIMD flag
         run: |
           grep -o 'data:application/wasm;base64,[A-Za-z0-9+/=]*' public/wasm/whisper.js \
             | head -n1 | cut -d, -f2 | base64 -d > /tmp/whisper.wasm
-          npx --yes @wasm-tools/wasm-feature /tmp/whisper.wasm | grep -q 'simd:true'
+          wasm-opt --detect-features /tmp/whisper.wasm | grep -q '+simd'
       - name: Post-build checks
         run: |
           test -f public/wasm/whisper.js

--- a/app/src/wasm.d.ts
+++ b/app/src/wasm.d.ts
@@ -1,9 +1,9 @@
 declare module '/wasm/whisper.js' {
-  const factory: () => Promise<any>;
+  const factory: () => Promise<Record<string, unknown>>;
   export default factory;
 }
 
 declare module 'public/wasm/whisper.js' {
-  const factory: () => Promise<any>;
+  const factory: () => Promise<Record<string, unknown>>;
   export default factory;
 }

--- a/app/src/wasm/loader.ts
+++ b/app/src/wasm/loader.ts
@@ -1,10 +1,13 @@
-/// <reference path="../wasm.d.ts" />
-// @ts-ignore -- WASM factory has no TypeScript definitions
+import '../wasm.d.ts';
+// @ts-expect-error -- WASM factory has no TypeScript definitions
 import whisper_factory from '/wasm/whisper.js';
 
 export const wasmReady = whisper_factory();
 
-export async function loadModel(Module: any, url: string) {
+export async function loadModel(
+  Module: { FS_writeFile(path: string, data: Uint8Array): void },
+  url: string,
+) {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to fetch model: ${res.status}`);
   const buf = await res.arrayBuffer();


### PR DESCRIPTION
## Summary
- install Binaryen in CI
- check WASM SIMD support via `wasm-opt --detect-features`
- clean up types for WASM loader

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c55022e288320a0215b8594f2b530