### PR TITLE
Fix WASM build script

### DIFF
--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -5,26 +5,35 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 WHISPER_REPO="https://github.com/ggerganov/whisper.cpp"
 
-# Load Emscripten environment
-eval "$(emsdk_env.sh)"
+# Load Emscripten environment if available
+if command -v emsdk_env.sh >/dev/null; then
+  # shellcheck disable=SC1091
+  source "$(command -v emsdk_env.sh)"
+fi
 
 git clone --depth 1 "$WHISPER_REPO"
 cd whisper.cpp
 
-# Build core static library
-cmake -B build-em -DWHISPER_WASM_SINGLE_FILE=ON \
+# Build core static library using emcmake
+emcmake cmake -B build-em \
+                 -DWHISPER_WASM_SINGLE_FILE=ON \
                  -DWHISPER_BUILD_TESTS=OFF \
-                 -DWHISPER_BUILD_EXAMPLES=OFF
+                 -DWHISPER_BUILD_EXAMPLES=OFF \
+                 .
 cmake --build build-em -j"$(nproc)"
 
 # Build JavaScript bindings
 cd bindings/javascript
-make clean
 make singlefile
 
 DEST="${GITHUB_WORKSPACE:-$PROJECT_ROOT}/public/wasm"
 mkdir -p "$DEST"
 cp whisper.js "$DEST/"
+
+# Also copy into the app's public folder for local builds
+APP_DEST="$PROJECT_ROOT/app/public/wasm"
+mkdir -p "$APP_DEST"
+cp whisper.js "$APP_DEST/"
 
 # Copy license
 LICENSE_DEST="$PROJECT_ROOT/third_party"


### PR DESCRIPTION
## Summary
- properly source the Emscripten environment
- use `emcmake` for configuring the build
- drop the failing `make clean` step
- copy the resulting `whisper.js` into the app's public folder

## Testing
- `npm ci`
- `npm run test:e2e` *(fails: Xvfb missing)*
- `npm run test:playwright` *(fails: browsers not installed)*
- `./scripts/build-wasm.sh` *(fails: `emcmake` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8670b1d48320bca847f0c5d1740a