### PR TITLE
Fix wasm build script and dynamic loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,20 @@ To test the app as a Progressive Web App on iOS:
 3. Launch the installed app from the Home Screen.
 
 The app should start without a 404 error and all routes will work offline.
+
+## Build & Run locally
+
+To rebuild the Whisper WASM bundle you need Emscripten. After cloning the repo run:
+
+```bash
+./scripts/bootstrap.sh       # one-time setup
+./scripts/build-wasm.sh
+```
+
+The generated `whisper.js` will be placed in `app/public/wasm/`. You can then start the dev server:
+
+```bash
+cd app
+npm install
+npm run dev
+```

--- a/app/src/wasm.d.ts
+++ b/app/src/wasm.d.ts
@@ -3,7 +3,17 @@ declare module '/wasm/whisper.js' {
   export default factory;
 }
 
+declare module '/wasm/whisper.single.js' {
+  const factory: () => Promise<Record<string, unknown>>;
+  export default factory;
+}
+
 declare module 'public/wasm/whisper.js' {
+  const factory: () => Promise<Record<string, unknown>>;
+  export default factory;
+}
+
+declare module 'public/wasm/whisper.single.js' {
   const factory: () => Promise<Record<string, unknown>>;
   export default factory;
 }

--- a/app/src/wasm/loader.ts
+++ b/app/src/wasm/loader.ts
@@ -1,8 +1,14 @@
 import '../wasm.d.ts';
-// @ts-expect-error -- WASM factory has no TypeScript definitions
-import whisper_factory from '/wasm/whisper.js';
 
-export const wasmReady = whisper_factory();
+export const wasmReady = (async () => {
+  const url = (typeof crossOriginIsolated !== 'undefined' && !crossOriginIsolated)
+    ? '/wasm/whisper.single.js'
+    : '/wasm/whisper.js';
+  const factory = (await import(/* @vite-ignore */ url)).default as () => Promise<Record<string, unknown>>;
+  const mod = await factory();
+  console.log('wasm ready');
+  return mod;
+})();
 
 export async function loadModel(
   Module: { FS_writeFile(path: string, data: Uint8Array): void },

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -11,37 +11,27 @@ if command -v emsdk_env.sh >/dev/null; then
   source "$(command -v emsdk_env.sh)"
 fi
 
+
 git clone --depth 1 "$WHISPER_REPO"
 cd whisper.cpp
 
-# Build core static library using emcmake
-emcmake cmake -B build-em \
-                 -DWHISPER_WASM_SINGLE_FILE=ON \
-                 -DWHISPER_BUILD_TESTS=OFF \
-                 -DWHISPER_BUILD_EXAMPLES=OFF \
-                 .
-cmake --build build-em -j"$(nproc)"
+# Build WebAssembly bundle
+make wasm -j"$(nproc)" \
+    WHISPER_WASM_SIMD=1 \
+    WHISPER_WASM_SINGLE_FILE=1 \
+    WHISPER_OPENMP=0
 
-###############################################
-# Build JavaScript / WASM bindings
-###############################################
-
-# Build the libwhisper target which produces whisper.js and the worker
-cmake --build build-em --target libwhisper -j"$(nproc)"
-
-# Artifacts are placed in build-em/bin/ by CMake. Copy them where Vite expects.
+# Artifacts are placed in wasm/ by Make. Copy them where Vite expects.
 DEST="${GITHUB_WORKSPACE:-$PROJECT_ROOT}/public/wasm"
 mkdir -p "$DEST"
-cp build-em/bin/libwhisper.js "$DEST/whisper.js"
-cp build-em/bin/libwhisper.worker.js "$DEST/"
+cp wasm/whisper.js "$DEST/whisper.js"
 
 # Also copy into the app's public folder for local builds
 APP_DEST="$PROJECT_ROOT/app/public/wasm"
 mkdir -p "$APP_DEST"
-cp build-em/bin/libwhisper.js "$APP_DEST/whisper.js"
-cp build-em/bin/libwhisper.worker.js "$APP_DEST/"
+cp wasm/whisper.js "$APP_DEST/whisper.js"
 
 # Copy license
 LICENSE_DEST="$PROJECT_ROOT/third_party"
 mkdir -p "$LICENSE_DEST"
-cp ../../LICENSE "$LICENSE_DEST/LICENSE-whisper-cpp"
+cp LICENSE "$LICENSE_DEST/LICENSE-whisper-cpp"

--- a/tests/whisper.spec.ts
+++ b/tests/whisper.spec.ts
@@ -6,6 +6,6 @@ test('whisper wasm loads', async ({ page }) => {
   const messages: string[] = [];
   page.on('console', msg => messages.push(msg.text()));
   await page.goto('http://localhost:4173/test-whisper.html');
-  await expect.poll(() => messages.includes('wasm ready')).toBe(true);
-  await expect.poll(() => messages.includes('Model ok')).toBe(true);
+  await expect.poll(() => messages.includes('wasm ready'), { timeout: 15000 }).toBe(true);
+  await expect.poll(() => messages.includes('Model ok'), { timeout: 15000 }).toBe(true);
 });


### PR DESCRIPTION
## Summary
- build wasm via `make wasm` and copy to app
- load wasm dynamically with single-thread fallback
- adjust TS types and Playwright test
- add local build instructions

## Testing
- `pre-commit run --files scripts/build-wasm.sh app/src/wasm/loader.ts app/src/wasm.d.ts tests/whisper.spec.ts README.md`
- `npm ci`
- `npx playwright install --with-deps`
- `npm run test:playwright` *(fails: wasm ready message not emitted)*

------
https://chatgpt.com/codex/tasks/task_e_686d8c34c03c8320b614b0c359f9dd43