### PR TITLE
Fix wasm build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ To rebuild the Whisper WASM bundle you need Emscripten. After cloning the repo r
 ./scripts/build-wasm.sh
 ```
 
-The generated `whisper.js` will be placed in `app/public/wasm/`. You can then start the dev server:
+The generated `whisper.js` (and `whisper.wasm` when not using the single-file mode)
+will be placed in `app/public/wasm/` as well as `public/wasm/`. You can then start the dev server:
 
 ```bash
 cd app

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -20,7 +20,9 @@ cd whisper.cpp
 ###########################################
 
 emcmake cmake -S . -B build-em \
+  -DWHISPER_BUILD_EM=ON \
   -DWHISPER_WASM_SINGLE_FILE=ON \
+  -DWHISPER_WASM_SIMD=ON \
   -DWHISPER_BUILD_TESTS=OFF \
   -DWHISPER_BUILD_EXAMPLES=OFF
 
@@ -32,8 +34,8 @@ cmake --build build-em --target whisper -j"$(nproc)"
 
 DEST="${GITHUB_WORKSPACE:-$PROJECT_ROOT}/public/wasm"
 mkdir -p "$DEST"
-cp build-em/bin/whisper.js        "$DEST/"
-cp build-em/bin/whisper.worker.js "$DEST/" || true
+cp build-em/bin/whisper*.js   "$DEST"/
+cp build-em/bin/whisper*.wasm "$DEST"/ 2>/dev/null || true
 
 # sanity log
 echo "Copied WASM bundle:"
@@ -42,8 +44,8 @@ ls -lh "$DEST"
 # Also copy into the app's public folder for local builds
 APP_DEST="$PROJECT_ROOT/app/public/wasm"
 mkdir -p "$APP_DEST"
-cp build-em/bin/whisper.js        "$APP_DEST/whisper.js"
-cp build-em/bin/whisper.worker.js "$APP_DEST/" || true
+cp build-em/bin/whisper*.js   "$APP_DEST"/
+cp build-em/bin/whisper*.wasm "$APP_DEST"/ 2>/dev/null || true
 
 # Copy license
 LICENSE_DEST="$PROJECT_ROOT/third_party"


### PR DESCRIPTION
## Summary
- enable JS/WASM bindings for whisper.cpp
- copy JS/WASM artifacts generically
- document locations of generated files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:playwright` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686d96779588832095020086551a875e