### PR TITLE
Fix WASM build

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           node - <<'NODE'
           const fs = require('fs');
-          const m = fs.readFileSync('public/wasm/whisper.js', 'utf8')
+          const m = fs.readFileSync('public/wasm/whisper-web.js', 'utf8')
             .match(/data:application\/wasm;base64,([A-Za-z0-9+/=]+)/);
           if (!m) process.exit(42);
           fs.writeFileSync('/tmp/whisper.wasm', Buffer.from(m[1], 'base64'));
@@ -38,7 +38,7 @@ jobs:
           wasm-opt --detect-features /tmp/whisper.wasm | grep -q '+simd'
       - name: Post-build checks
         run: |
-          test -f public/wasm/whisper.js
+          test -f public/wasm/whisper-web.js
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ To rebuild the Whisper WASM bundle you need Emscripten. After cloning the repo r
 ./scripts/build-wasm.sh
 ```
 
-The generated `whisper.js` (and `whisper.wasm` when not using the single-file mode)
-will be placed in `app/public/wasm/` as well as `public/wasm/`. You can then start the dev server:
+The generated `whisper-web.js` and `whisper-web.wasm` will be placed in `app/public/wasm/` as well as `public/wasm/`. You can then start the dev server:
 
 ```bash
 cd app

--- a/app/public/test-whisper.html
+++ b/app/public/test-whisper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <body>
 <script type="module">
-import whisper_factory from './wasm/whisper.js';
+import whisper_factory from './wasm/whisper-web.js';
 import { loadModel } from '/src/wasm/loader.ts';
 whisper_factory().then(async (mod) => {
   console.log('wasm ready');

--- a/app/src/wasm.d.ts
+++ b/app/src/wasm.d.ts
@@ -1,19 +1,19 @@
-declare module '/wasm/whisper.js' {
+declare module '/wasm/whisper-web.js' {
   const factory: () => Promise<Record<string, unknown>>;
   export default factory;
 }
 
-declare module '/wasm/whisper.single.js' {
+declare module '/wasm/whisper-web.single.js' {
   const factory: () => Promise<Record<string, unknown>>;
   export default factory;
 }
 
-declare module 'public/wasm/whisper.js' {
+declare module 'public/wasm/whisper-web.js' {
   const factory: () => Promise<Record<string, unknown>>;
   export default factory;
 }
 
-declare module 'public/wasm/whisper.single.js' {
+declare module 'public/wasm/whisper-web.single.js' {
   const factory: () => Promise<Record<string, unknown>>;
   export default factory;
 }

--- a/app/src/wasm/loader.ts
+++ b/app/src/wasm/loader.ts
@@ -2,8 +2,8 @@ import '../wasm.d.ts';
 
 export const wasmReady = (async () => {
   const url = (typeof crossOriginIsolated !== 'undefined' && !crossOriginIsolated)
-    ? '/wasm/whisper.single.js'
-    : '/wasm/whisper.js';
+    ? '/wasm/whisper-web.single.js'
+    : '/wasm/whisper-web.js';
   const factory = (await import(/* @vite-ignore */ url)).default as () => Promise<Record<string, unknown>>;
   const mod = await factory();
   console.log('wasm ready');

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -21,15 +21,20 @@ cd whisper.cpp
 
 emcmake cmake -S . -B build \
   -DWHISPER_WASM_SINGLE_FILE=ON \
+  -DWHISPER_BUILD_WEB=ON \
   -DWHISPER_BUILD_TESTS=OFF \
   -DWHISPER_BUILD_EXAMPLES=OFF \
   -DCMAKE_BUILD_TYPE=Release
 
-cmake --build build -j"$(nproc)"
+cmake --build build --target whisper-web -j"$(nproc)"
 
 # copy artifacts into static assets
 mkdir -p "$PROJECT_ROOT/public/wasm"
-cp build/bin/whisper.* "$PROJECT_ROOT/public/wasm/"
+cp build/bin/whisper-web.* "$PROJECT_ROOT/public/wasm/"
+
+if ! ls "$PROJECT_ROOT/public/wasm/whisper-web."* 1>/dev/null 2>&1; then
+  echo "::error::WASM artefact not found"; exit 1
+fi
 
 ###########################################
 #  Copy JS artifacts into the web app     #
@@ -37,8 +42,8 @@ cp build/bin/whisper.* "$PROJECT_ROOT/public/wasm/"
 
 DEST="${GITHUB_WORKSPACE:-$PROJECT_ROOT}/public/wasm"
 mkdir -p "$DEST"
-cp build/bin/whisper.js "$DEST/"
-cp build/bin/whisper.wasm "$DEST/" 2>/dev/null || true
+cp build/bin/whisper-web.js "$DEST/"
+cp build/bin/whisper-web.wasm "$DEST/" 2>/dev/null || true
 
 # sanity log
 echo "Copied WASM bundle:"
@@ -47,8 +52,8 @@ ls -lh "$DEST"
 # Also copy into the app's public folder for local builds
 APP_DEST="$PROJECT_ROOT/app/public/wasm"
 mkdir -p "$APP_DEST"
-cp build/bin/whisper.js "$APP_DEST/" 
-cp build/bin/whisper.wasm "$APP_DEST/" 2>/dev/null || true
+cp build/bin/whisper-web.js "$APP_DEST/"
+cp build/bin/whisper-web.wasm "$APP_DEST/" 2>/dev/null || true
 
 # Copy license
 LICENSE_DEST="$PROJECT_ROOT/third_party"

--- a/scripts/check_size.sh
+++ b/scripts/check_size.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 MAX=10000000
-FILE="app/public/wasm/whisper.js"
+FILE="app/public/wasm/whisper-web.js"
 
 if [ -f "$FILE" ]; then
   SIZE=$(gzip -c "$FILE" | wc -c)


### PR DESCRIPTION
## Summary
- build the correct `whisper-web` target from whisper.cpp
- copy `whisper-web.*` artifacts and check for presence
- adjust size check, loader and HTML to new file names
- update CI workflow and docs

## Testing
- `./scripts/check_size.sh`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix app run build` *(fails: missing dependencies and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e9eecdd24832080d75c23d8770e48