### PR TITLE
Fix build-wasm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To rebuild the Whisper WASM bundle you need Emscripten. After cloning the repo r
 ./scripts/build-wasm.sh
 ```
 
-The generated `whisper-web.js` and `whisper-web.wasm` will be placed in `app/public/wasm/` as well as `public/wasm/`. You can then start the dev server:
+The generated `whisper-web.js` (and the fallback `whisper-web.single.js`) will be placed in `app/public/wasm/` as well as `public/wasm/`. You can then start the dev server:
 
 ```bash
 cd app

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -3,7 +3,8 @@ set -eux
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
-WHISPER_REPO="https://github.com/ggerganov/whisper.cpp"
+# Use actively maintained repository
+WHISPER_REPO="https://github.com/ggml-org/whisper.cpp"
 
 # Load Emscripten environment if available
 if command -v emsdk_env.sh >/dev/null; then
@@ -21,18 +22,28 @@ cd whisper.cpp
 
 emcmake cmake -S . -B build \
   -DWHISPER_WASM_SINGLE_FILE=ON \
-  -DWHISPER_BUILD_WEB=ON \
   -DWHISPER_BUILD_TESTS=OFF \
-  -DWHISPER_BUILD_EXAMPLES=OFF \
+  -DWHISPER_BUILD_EXAMPLES=ON \
   -DCMAKE_BUILD_TYPE=Release
 
-cmake --build build --target whisper-web -j"$(nproc)"
+# Build all targets. libmain.js/wasm will be placed in build/bin/
+cmake --build build --config Release -j"$(nproc)"
 
 # copy artifacts into static assets
 mkdir -p "$PROJECT_ROOT/public/wasm"
-cp build/bin/whisper-web.* "$PROJECT_ROOT/public/wasm/"
+# Rename libmain.js -> whisper-web.js (and single variant)
+if [ -f build/bin/libmain.js ]; then
+  cp build/bin/libmain.js "$PROJECT_ROOT/public/wasm/whisper-web.js"
+  cp build/bin/libmain.js "$PROJECT_ROOT/public/wasm/whisper-web.single.js"
+fi
+if [ -f build/bin/libmain.wasm ]; then
+  cp build/bin/libmain.wasm "$PROJECT_ROOT/public/wasm/whisper-web.wasm"
+fi
+if [ -d build/bin/whisper.wasm ]; then
+  cp -r build/bin/whisper.wasm/* "$PROJECT_ROOT/public/wasm/"
+fi
 
-if ! ls "$PROJECT_ROOT/public/wasm/whisper-web."* 1>/dev/null 2>&1; then
+if [ ! -f "$PROJECT_ROOT/public/wasm/whisper-web.js" ]; then
   echo "::error::WASM artefact not found"; exit 1
 fi
 
@@ -42,8 +53,16 @@ fi
 
 DEST="${GITHUB_WORKSPACE:-$PROJECT_ROOT}/public/wasm"
 mkdir -p "$DEST"
-cp build/bin/whisper-web.js "$DEST/"
-cp build/bin/whisper-web.wasm "$DEST/" 2>/dev/null || true
+if [ -f build/bin/libmain.js ]; then
+  cp build/bin/libmain.js "$DEST/whisper-web.js"
+  cp build/bin/libmain.js "$DEST/whisper-web.single.js"
+fi
+if [ -f build/bin/libmain.wasm ]; then
+  cp build/bin/libmain.wasm "$DEST/whisper-web.wasm"
+fi
+if [ -d build/bin/whisper.wasm ]; then
+  cp -r build/bin/whisper.wasm/* "$DEST/"
+fi
 
 # sanity log
 echo "Copied WASM bundle:"
@@ -52,8 +71,16 @@ ls -lh "$DEST"
 # Also copy into the app's public folder for local builds
 APP_DEST="$PROJECT_ROOT/app/public/wasm"
 mkdir -p "$APP_DEST"
-cp build/bin/whisper-web.js "$APP_DEST/"
-cp build/bin/whisper-web.wasm "$APP_DEST/" 2>/dev/null || true
+if [ -f build/bin/libmain.js ]; then
+  cp build/bin/libmain.js "$APP_DEST/whisper-web.js"
+  cp build/bin/libmain.js "$APP_DEST/whisper-web.single.js"
+fi
+if [ -f build/bin/libmain.wasm ]; then
+  cp build/bin/libmain.wasm "$APP_DEST/whisper-web.wasm"
+fi
+if [ -d build/bin/whisper.wasm ]; then
+  cp -r build/bin/whisper.wasm/* "$APP_DEST/"
+fi
 
 # Copy license
 LICENSE_DEST="$PROJECT_ROOT/third_party"


### PR DESCRIPTION
## Summary
- fetch wasm sources from ggml-org upstream instead of old fork
- build using updated CMake flags
- copy `libmain.js` to `whisper-web.js` and `whisper-web.single.js`
- document updated wasm artifacts in README

## Testing
- `pre-commit run --files scripts/build-wasm.sh README.md`
- `scripts/check_size.sh`

------
https://chatgpt.com/codex/tasks/task_e_68822af753b08320a034121c97705a58