### PR TITLE
fix: ensure deterministic wasm build

### DIFF
--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -12,8 +12,12 @@ if command -v emsdk_env.sh >/dev/null; then
   source "$(command -v emsdk_env.sh)"
 fi
 
+# Always operate from the project root so relative paths are predictable
+cd "$PROJECT_ROOT"
 
-git clone --depth 1 "$WHISPER_REPO"
+# Refresh the whisper.cpp clone to avoid failures on repeated builds
+rm -rf whisper.cpp
+git clone --depth 1 "$WHISPER_REPO" whisper.cpp
 cd whisper.cpp
 
 ###########################################


### PR DESCRIPTION
## Summary
- reset whisper.cpp clone on each build and run from project root for consistent paths

## Testing
- `bash -n scripts/build-wasm.sh`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896ffd79f948320a6213cac4d8faed9