### PR TITLE
chore: install pnpm in wasm build workflow

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -24,6 +24,12 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
       - name: Install deps
         run: pnpm install --frozen-lockfile
       - name: Check SIMD flag


### PR DESCRIPTION
## Summary
- install pnpm via pnpm/action-setup in build-wasm workflow

## Testing
- `pre-commit run --files .github/workflows/build-wasm.yml`
- `cd app && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6897039233648320949dc10e6b35dcff