### PR TITLE
Fix build workflow to install dependencies using npm

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -18,20 +18,15 @@ jobs:
       - name: Build whisper WASM
         run: ./scripts/build-wasm.sh
 
-      - name: Cache node_modules / pnpm
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
+          cache: npm
+          cache-dependency-path: app/package-lock.json
 
       - name: Install deps
-        run: pnpm install --frozen-lockfile
+        run: npm ci
+        working-directory: app
       - name: Check SIMD flag
         run: |
           node - <<'NODE'


### PR DESCRIPTION
## Summary
- replace pnpm setup with npm configuration in build-wasm workflow
- install dependencies from `app` directory and enable npm caching

## Testing
- `pre-commit run --files .github/workflows/build-wasm.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68970707ce988320be3ee5d2b3194497