### PR TITLE
Use relative asset URLs, add maskable icon and offline handling in service worker

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,14 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="/icons/placeholder.svg" sizes="any" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/placeholder.svg" />
-    <!-- TODO: заменить SVG-заглушку на реальные PNG-иконки и splash-экраны (см. тикет X) -->
+    <link rel="manifest" href="./manifest.json" />
+    <link rel="icon" href="./icons/placeholder.svg" sizes="any" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/placeholder.svg" />
     <title>Scriptrans</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -5,7 +5,14 @@
   "scope": "/scriptrans/",
   "display": "standalone",
   "theme_color": "#ffffff",
+  "background_color": "#ffffff",
   "icons": [
-    { "src": "/icons/placeholder.svg", "sizes": "any", "type": "image/svg+xml" }
+    { "src": "icons/placeholder.svg", "sizes": "any", "type": "image/svg+xml" },
+    {
+      "src": "icons/placeholder.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
   ]
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import { FileContext } from './FileContext';
 
 function Header() {
   const location = useLocation();
+  const iconPath = `${import.meta.env.BASE_URL}icons/placeholder.svg`;
   const step =
     location.pathname === '/progress'
       ? 'Progress'
@@ -17,7 +18,7 @@ function Header() {
     <header className="sticky top-0 bg-[color:var(--accent)] text-[color:var(--bg)] p-4">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-4">
-          <img src="/icons/placeholder.svg" alt="logo" className="h-6 w-6" />
+          <img src={iconPath} alt="logo" className="h-6 w-6" />
           <span className="font-bold">{step}</span>
         </div>
         <nav className="flex flex-wrap gap-2 justify-center">

--- a/app/src/sw.ts
+++ b/app/src/sw.ts
@@ -11,6 +11,7 @@ declare const self: ServiceWorkerGlobalScope;
 declare const __SW_VERSION__: string;
 
 const CACHE_NAME = `shell-v${__SW_VERSION__}`;
+const OFFLINE_URL = new URL('offline.html', self.registration.scope).pathname;
 setCacheNameDetails({ precache: CACHE_NAME, prefix: '', suffix: '' });
 
 self.addEventListener('install', () => {
@@ -32,11 +33,13 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('message', (event) => {
-  if (event.data === 'SKIP_WAITING') self.skipWaiting();
+  if (event.data === 'SKIP_WAITING' || event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });
 
 precacheAndRoute(self.__WB_MANIFEST);
-precacheAndRoute([{ url: '/offline.html', revision: '' }]);
+precacheAndRoute([{ url: OFFLINE_URL, revision: null }]);
 
 registerRoute(
   /\.(?:js|css|html|ico|png|svg)$/, 
@@ -53,7 +56,6 @@ registerRoute(
     } catch {
       /* ignore errors */
     }
-    return (response ?? (await caches.match('/offline.html'))) as Response;
+    return (response ?? (await caches.match(OFFLINE_URL))) as Response;
   }
 );
-

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -26,11 +26,18 @@ export default defineConfig({
         scope: '/scriptrans/',
         display: 'standalone',
         theme_color: '#ffffff',
+        background_color: '#ffffff',
         icons: [
           {
-            src: '/icons/placeholder.svg',
+            src: 'icons/placeholder.svg',
             sizes: 'any',
             type: 'image/svg+xml'
+          },
+          {
+            src: 'icons/placeholder.svg',
+            sizes: 'any',
+            type: 'image/svg+xml',
+            purpose: 'maskable'
           }
         ]
       }


### PR DESCRIPTION
### Motivation
- Ensure assets resolve correctly when the app is served from different base paths and make the PWA manifest more complete by adding `background_color` and a `maskable` icon entry.
- Improve offline behavior by consistently referencing the precached offline page and handling the `SKIP_WAITING` message shape from the service worker registration.

### Description
- Converted absolute paths to relative paths in `app/index.html` for `manifest`, `icon`, and the app script by changing `/...` to `./...` and removed a placeholder comment.
- Made the app header use the runtime base URL for the logo by constructing `iconPath` with ``import.meta.env.BASE_URL`` and replaced the hardcoded `/icons/placeholder.svg` with that variable in `app/src/App.tsx`.
- Updated the service worker in `app/src/sw.ts` to compute `OFFLINE_URL` relative to the service worker scope, accept message objects with `{ type: 'SKIP_WAITING' }`, and use `OFFLINE_URL` in `precacheAndRoute` and when falling back to the cached offline page.
- Enhanced the PWA manifest in `app/public/manifest.json` and `vite.config.ts` by adding `background_color` and a `maskable` icon entry, and changed icon `src` entries to relative paths (removed leading `/`).

### Testing
- Ran a TypeScript type check with `tsc --noEmit` and it succeeded.
- Performed a Vite production build with `npm run build` and the build completed successfully with the service worker precache including the offline page.
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88b736cb0832087b738b955fdfcc3)